### PR TITLE
fix: updated query cache module registration order

### DIFF
--- a/src/SImpl.CQRS.Queries.Cache/Module/QueryCacheModule.cs
+++ b/src/SImpl.CQRS.Queries.Cache/Module/QueryCacheModule.cs
@@ -3,12 +3,13 @@ using SImpl.Cache;
 using SImpl.Cache.Module;
 using SImpl.CQRS.Queries.Cache.Decorators;
 using SImpl.CQRS.Queries.Cache.Services;
+using SImpl.CQRS.Queries.Module;
 using SImpl.Host.Builders;
 using SImpl.Modules;
 
 namespace SImpl.CQRS.Queries.Cache.Module
 {
-    [DependsOn(typeof(CacheModule))]
+    [DependsOn(typeof(CacheModule), typeof(QueryModule))]
     public class QueryCacheModule : IHostBuilderConfigureModule, IServicesCollectionConfigureModule, ICacheExtensionModule
     {
         public QueryCacheModuleConfig Config { get; }


### PR DESCRIPTION
Updated module registration order (dependencies).

cc: @K3llr 

PS: if you could annotate this PR with hacktoberfest-accepted label after successfully review. More details: https://hacktoberfest.com/participation/#maintainers

![image](https://user-images.githubusercontent.com/29370044/193396249-ee1a9072-8737-41e8-bb18-1cc4f1efe854.png)
