### PR TITLE
Fix: rebus messaging registration

### DIFF
--- a/src/SImpl.Messaging.CQRS.Rebus/Module/MessagingCqrsModule.cs
+++ b/src/SImpl.Messaging.CQRS.Rebus/Module/MessagingCqrsModule.cs
@@ -20,7 +20,7 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
     public class MessagingCqrsModule : IServicesCollectionConfigureModule, IAspNetPostModule
     {
         public MessagingCqrsModuleConfig Config { get; }
-        
+
         public string Name => nameof(MessagingCqrsModule);
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
@@ -43,13 +43,13 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
                             {
                                 var eventTypes = Config.RegisteredEventAssemblies.SelectMany(s => s.GetTypes())
                                     .Where(p => p.IsAssignableTo(typeof(IEvent)));
-                            
+
                                 foreach (var eventType in eventTypes)
                                 {
                                     await bus.Subscribe(eventType);
                                 }
                             }
-                            
+
                             await Config.BusConfigureDelegate.Invoke(bus);
                         });
                     });
@@ -60,7 +60,7 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
         {
             Config = config;
         }
-        
+
         public void ConfigureServices(IServiceCollection services)
         {
             // Register commands
@@ -68,13 +68,13 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
             {
                 services.AddSingleton<IMessagingCommandDispatcher, RebusCommandDispatcher>();
             }
-            
+
             RegisterMessageHandlers(
-                services, 
-                Config.RegisteredCommandAssemblies, 
+                services,
+                Config.RegisteredCommandAssemblies,
                 Config.RegisteredCommandTypes,
-                typeof(ICommand), 
-                typeof(IHandleMessages<>), 
+                typeof(ICommand),
+                typeof(IHandleMessages<>),
                 typeof(CommandMessageHandler<>));
 
             // Register events
@@ -82,13 +82,13 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
             {
                 services.AddSingleton<IMessagingEventDispatcher, RebusEventDispatcher>();
             }
-            
+
             RegisterMessageHandlers(
-                services, 
-                Config.RegisteredEventAssemblies, 
-                Config.RegisteredEventTypes, 
-                typeof(IEvent), 
-                typeof(IHandleMessages<>), 
+                services,
+                Config.RegisteredEventAssemblies,
+                Config.RegisteredEventTypes,
+                typeof(IEvent),
+                typeof(IHandleMessages<>),
                 typeof(EventMessageHandler<>));
 
             // Register messageHandler buffer
@@ -97,14 +97,14 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
             var bufferMessageHandlerType = typeof(BufferedMessageHandler<>);
             var bufferHandlerType = typeof(IBufferHandler<>);
             var registeredBufferHandlers = new List<Type>();
-            
+
             foreach (var messagesBuffer in Config.RegisteredMessageHandlerBuffers)
             {
                 // Register config
                 var concreteBufferConfigType = handlerBufferConfigType.MakeGenericType(messagesBuffer.MessageType);
                 var config = Activator.CreateInstance(concreteBufferConfigType, messagesBuffer.MaxTimeSpan, messagesBuffer.MaxMessageCount);
                 services.AddSingleton(concreteBufferConfigType, config);
-                
+
                 // Register handler
                 var genericMessageHandler = messageHandlerType.MakeGenericType(messagesBuffer.MessageType);
                 var genericBufferMessageHandler = bufferMessageHandlerType.MakeGenericType(messagesBuffer.MessageType);
@@ -118,19 +118,19 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
                     services.AddSingleton(genericBufferHandlerType, messagesBuffer.BufferHandlerType);
                 }
             }
-            
+
             // Register commandDispatch buffer
             var dispatchBufferConfigType = typeof(DispatchBufferConfig<>);
             var dispatcherType = typeof(ICommandBufferDispatcher<>);
             var commandBufferDispatcherType = typeof(CommandBufferDispatcher<>);
-            
+
             foreach (var messagesBuffer in Config.RegisteredMessageDispatcherBuffers)
             {
                 // Register config
                 var concreteBufferConfigType = dispatchBufferConfigType.MakeGenericType(messagesBuffer.MessageType);
                 var config = Activator.CreateInstance(concreteBufferConfigType, messagesBuffer.MaxTimeSpan, messagesBuffer.MaxMessageCount);
                 services.AddSingleton(concreteBufferConfigType, config);
-                
+
                 // Register dispatcher
                 var genericDispatcher = dispatcherType.MakeGenericType(messagesBuffer.MessageType);
                 var genericCommandBufferDispatcher = commandBufferDispatcherType.MakeGenericType(messagesBuffer.MessageType);
@@ -147,15 +147,15 @@ namespace SImpl.Messaging.CQRS.Rebus.Module
         }
 
         private void RegisterMessageHandlers(
-            IServiceCollection services, 
-            IReadOnlyList<Assembly> assemblies, 
+            IServiceCollection services,
+            IReadOnlyList<Assembly> assemblies,
             IReadOnlyList<Type> types,
-            Type lookForType, 
-            Type genericInterface, 
+            Type lookForType,
+            Type genericInterface,
             Type genericImpl)
         {
             var allTypes = assemblies.SelectMany(s => s.GetTypes())
-                .Where(p => p.IsAssignableTo(lookForType))
+                .Where(p => p.IsAssignableTo(lookForType) && p.IsAbstract == false)
                 .Union(types)
                 .Distinct();
 


### PR DESCRIPTION
Fix for skipping the abstract classes registration into DI when reading types from assemblies.